### PR TITLE
MCR-3692 datamodel-plugin generates structure schema with wrong element order

### DIFF
--- a/src/main/resources/datamodel2schema.xsl
+++ b/src/main/resources/datamodel2schema.xsl
@@ -49,8 +49,8 @@
             <xs:element ref="parents" minOccurs="0" />
           </xsl:if>
           <xsl:if test="@isParent = 'true'">
-            <xs:element ref="children" minOccurs="0" />
             <xs:element ref="childrenOrder" minOccurs="0" />
+            <xs:element ref="children" minOccurs="0" />
           </xsl:if>
           <xsl:if test="@hasDerivates = 'true'">
             <xs:element ref="derobjects" minOccurs="0" />


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3692)

## Summary

- `datamodel2schema.xsl` generated the `structure` complex type with `children` before `childrenOrder`, but MyCoRe (after MCR-3375) actually serializes `childrenOrder` before `children` (and `derobjects` last).
- Since `<xs:sequence>` enforces ordering, validation of expanded objects containing both elements failed.
- Fix swaps the two elements so the generated schema matches `MCRObjectStructure.createXML()` + `MCRExpandedObjectStructure.createXML()`.

## Test plan

- [x] `mvn clean install` succeeds
- [ ] Regenerate a datamodel schema with the new plugin and validate an expanded MyCoRe object against it